### PR TITLE
View discussion topic in schedule+add discussion topic

### DIFF
--- a/frontend/src/app/(ui)/dashboard/schedule/event-item.tsx
+++ b/frontend/src/app/(ui)/dashboard/schedule/event-item.tsx
@@ -1,85 +1,109 @@
-'use client';
+"use client";
 
+import * as React from "react";
 
-import * as React from 'react';
+import { useUser } from "@auth0/nextjs-auth0/client";
 
-import { useUser } from '@auth0/nextjs-auth0/client';
+import AccessTimeIcon from "@mui/icons-material/AccessTime";
+import EmailIcon from "@mui/icons-material/Email";
+import PendingActionsIcon from "@mui/icons-material/PendingActions";
+import DateRangeIcon from "@mui/icons-material/DateRange";
+import DoNotDisturbIcon from "@mui/icons-material/DoNotDisturb";
+import DoneIcon from "@mui/icons-material/Done";
+import PhoneIphoneIcon from "@mui/icons-material/PhoneIphone";
+import PersonPinCircleIcon from "@mui/icons-material/PersonPinCircle";
+import FormatAlignLeftIcon from "@mui/icons-material/FormatAlignLeft";
+import {
+  Stack,
+  Avatar,
+  Typography,
+  Button,
+  Divider,
+  Tooltip,
+  Dialog,
+  DialogContent,
+} from "@mui/material";
 
-import AccessTimeIcon from '@mui/icons-material/AccessTime';
-import EmailIcon from '@mui/icons-material/Email';
-import PendingActionsIcon from '@mui/icons-material/PendingActions';
-import DateRangeIcon from '@mui/icons-material/DateRange';
-import DoNotDisturbIcon from '@mui/icons-material/DoNotDisturb';
-import DoneIcon from '@mui/icons-material/Done';
-import PhoneIphoneIcon from '@mui/icons-material/PhoneIphone';
-import PersonPinCircleIcon from '@mui/icons-material/PersonPinCircle';
-import FormatAlignLeftIcon from '@mui/icons-material/FormatAlignLeft';
-import { Stack, Avatar, Typography, Button, Divider, Tooltip, Dialog, DialogContent }
-  from '@mui/material';
-
-import { toTitleCase, toPhoneNumber, toAppointmentDateOnly, toAppointmentTimeOnly } 
-  from '@/app/_lib/utils';
-import { TableUpdate }
-  from '@/app/_lib/data';
-
+import {
+  toTitleCase,
+  toPhoneNumber,
+  toAppointmentDateOnly,
+  toAppointmentTimeOnly,
+} from "@/app/_lib/utils";
+import { TableUpdate } from "@/app/_lib/data";
 
 /**
  * Component for displaying the EventItem popup on the Schedule Page
  * @param appointment - Appointment data for the selected appointment
  * @param event - State variable and setter function for controlling the popup's open state
  * @param refetch - Refetch functions for tutor and tutee appointment queries
- * @returns 
- */  
-export default function EventItem(
-  { appointment, event: [eventOpen, setEventOpen], refetch: [tutorRefetch, tuteeRefetch] }: 
-  { appointment: Appointment | undefined, event: [boolean, Function], refetch: [Function, Function] }
-){
-  const [startDate, endDate] = [new Date(appointment ? appointment.startDateTimeString : ""), new Date(appointment ? appointment.endDateTimeString : "")];
-  
+ * @returns
+ */
+export default function EventItem({
+  appointment,
+  event: [eventOpen, setEventOpen],
+  refetch: [tutorRefetch, tuteeRefetch],
+}: {
+  appointment: Appointment | undefined;
+  event: [boolean, Function];
+  refetch: [Function, Function];
+}) {
+  const [startDate, endDate] = [
+    new Date(appointment ? appointment.startDateTimeString : ""),
+    new Date(appointment ? appointment.endDateTimeString : ""),
+  ];
 
   // Mutation variable for appointment/update
   const updateSchedule = TableUpdate("appointment/update");
 
-
   // Handler functions for confirming and cancelling appointments
   const handleConfirm = () => {
     appointment &&
-    updateSchedule.mutate({
-      appointment_id_old: appointment.appointmentId,
-      is_confirmed_new: true,
-    }, {
-      onSuccess: () => {
-        tutorRefetch(); tuteeRefetch();
-        setEventOpen(false);
-      }
-    });
+      updateSchedule.mutate(
+        {
+          appointment_id_old: appointment.appointmentId,
+          is_confirmed_new: true,
+        },
+        {
+          onSuccess: () => {
+            tutorRefetch();
+            tuteeRefetch();
+            setEventOpen(false);
+          },
+        }
+      );
   };
 
   const handleCancel = () => {
     appointment &&
-    updateSchedule.mutate({
-      appointment_id_old: appointment.appointmentId,
-      is_cancelled_new: true,
-    }, {
-      onSuccess: () => {
-        tutorRefetch(); tuteeRefetch();
-        setEventOpen(false);
-      }
-    });
+      updateSchedule.mutate(
+        {
+          appointment_id_old: appointment.appointmentId,
+          is_cancelled_new: true,
+        },
+        {
+          onSuccess: () => {
+            tutorRefetch();
+            tuteeRefetch();
+            setEventOpen(false);
+          },
+        }
+      );
   };
-
 
   // Data to be displayed on the appointment event
   const appointmentDateOnly = toAppointmentDateOnly(startDate, endDate);
   const appointmentTimeOnly = toAppointmentTimeOnly(startDate, endDate);
-  const {user} = useUser();
+  const { user } = useUser();
   const sessionEmail = user?.email;
   const isCancelled = appointment?.isCancelled;
   const isConfirmed = appointment?.isConfirmed;
   const isPending = !appointment?.isCancelled && !appointment?.isConfirmed;
 
   var avatar = appointment?.tutorPictureUrl;
-  var name = toTitleCase(`${appointment?.tutorFirstName} ${appointment?.tutorLastName}`);
+  var name = toTitleCase(
+    `${appointment?.tutorFirstName} ${appointment?.tutorLastName}`
+  );
   var email = appointment?.tutorEmail;
   var phone = toPhoneNumber(appointment?.tutorPhoneNumber.toString());
   var major = appointment?.tutorMajorAbbreviation.toUpperCase();
@@ -89,119 +113,222 @@ export default function EventItem(
   // Change data to tutee if the signed in user is the current tutor on the appointment
   if (sessionEmail === appointment?.tutorEmail) {
     avatar = appointment?.tuteePictureUrl;
-    name = toTitleCase(`${appointment?.tuteeFirstName} ${appointment?.tuteeLastName}`);
+    name = toTitleCase(
+      `${appointment?.tuteeFirstName} ${appointment?.tuteeLastName}`
+    );
     email = appointment?.tuteeEmail;
     phone = toPhoneNumber(appointment?.tuteePhoneNumber.toString());
     major = appointment?.tuteeMajorAbbreviation.toUpperCase();
     seniority = toTitleCase(appointment?.tuteeSeniorityName);
-    target = "Your Tutee"
+    target = "Your Tutee";
   }
 
-
   return (
-    <Dialog 
-      open={eventOpen} onClose={() => setEventOpen(false)}
-      maxWidth="md" fullWidth
+    <Dialog
+      open={eventOpen}
+      onClose={() => setEventOpen(false)}
+      maxWidth="md"
+      fullWidth
     >
       <DialogContent>
-
         <Stack direction="column" spacing={3}>
-
           {/* Tutor/Tutee Header */}
-          <Stack direction="row" spacing={2} pb={1} borderBottom={1} borderColor="divider">
+          <Stack
+            direction="row"
+            spacing={2}
+            pb={1}
+            borderBottom={1}
+            borderColor="divider"
+          >
             <Avatar src={avatar} sx={{ width: 75, height: 75 }} />
-            
-            <Stack direction="column" justifyContent="center" alignItems="flex-start">
-              <Typography variant="body2" color="text.secondary" borderBottom={1} borderColor="divider"> {target} </Typography>
-              
-              <Stack direction="row" spacing={2} alignItems="center" divider={ <Divider orientation="vertical" sx={{ height: '75%' }} /> }>
-                <Typography variant="h4" fontWeight="bold"> {name} </Typography>
-                <Typography variant="body1" color="text.secondary"> {major} </Typography>
-                <Typography variant="body1" color="text.secondary"> {seniority} </Typography>
+            <Stack
+              direction="column"
+              justifyContent="center"
+              alignItems="flex-start"
+            >
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                borderBottom={1}
+                borderColor="divider"
+              >
+                {" "}
+                {target}{" "}
+              </Typography>
+              <Stack
+                direction="row"
+                spacing={2}
+                alignItems="center"
+                divider={
+                  <Divider orientation="vertical" sx={{ height: "75%" }} />
+                }
+              >
+                <Typography variant="h4" fontWeight="bold">
+                  {" "}
+                  {name}{" "}
+                </Typography>
+                <Typography variant="body1" color="text.secondary">
+                  {" "}
+                  {major}{" "}
+                </Typography>
+                <Typography variant="body1" color="text.secondary">
+                  {" "}
+                  {seniority}{" "}
+                </Typography>
               </Stack>
             </Stack>
           </Stack>
-          
+
           {/* Body */}
           <Stack direction="column" spacing={3}>
-            <Stack direction="row" alignItems="center" justifyContent="space-between">
-              <Stack direction="row" spacing={1} alignItems="center" width="55%">
-              <PendingActionsIcon fontSize="large" />
-              <Typography variant="h6"> 
-                {
-                  appointment?.isConfirmed ? "Confirmed!" : 
-                  ( appointment?.isCancelled ? "Cancelled" : 
-                    ( sessionEmail === appointment?.tutorEmail ? "Awaiting Your Decision . . ." :
-                      "Awaiting Tutor's Decision . . ."
-                    )
-                  )
-                } 
-              </Typography>
-
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                width="55%"
+              >
+                <PendingActionsIcon fontSize="large" />
+                <Typography variant="h6">
+                  {appointment?.isConfirmed
+                    ? "Confirmed!"
+                    : appointment?.isCancelled
+                    ? "Cancelled"
+                    : sessionEmail === appointment?.tutorEmail
+                    ? "Awaiting Your Decision . . ."
+                    : "Awaiting Tutor's Decision . . ."}
+                </Typography>
               </Stack>
-
-              <Stack direction="row" spacing={1} alignItems="center" width="45%">
-              <PersonPinCircleIcon fontSize="large" />
-              <Typography variant="h5"> {toTitleCase(appointment?.locationName)} </Typography>
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                width="45%"
+              >
+                <PersonPinCircleIcon fontSize="large" />
+                <Typography variant="h5">
+                  {" "}
+                  {toTitleCase(appointment?.locationName)}{" "}
+                </Typography>
               </Stack>
             </Stack>
-
-            <Stack direction="row" alignItems="center" justifyContent="space-between">
-              <Stack direction="row" spacing={1} alignItems="center" width="55%">
+            <Stack
+              direction="row"
+              alignItems="center"
+              justifyContent="space-between"
+            >
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                width="55%"
+              >
                 <DateRangeIcon fontSize="large" />
                 <Typography variant="h6"> {appointmentDateOnly} </Typography>
               </Stack>
-
-              <Stack direction="row" spacing={1} alignItems="center" width="45%">
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                width="45%"
+              >
                 <AccessTimeIcon fontSize="large" />
                 <Typography variant="h6"> {appointmentTimeOnly} </Typography>
               </Stack>
             </Stack>
-
             <Stack direction="row" justifyContent="space-between">
-              <Stack direction="row" spacing={1} alignItems="center" width="55%">
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                width="55%"
+              >
                 <EmailIcon fontSize="large" />
-                <Tooltip title={email} placement="top-start" arrow slotProps={{ popper: { modifiers: [ { name: 'offset', options: { offset: [0, -14], } } ] } }}>
-                  <Typography variant="h6" noWrap> {email} </Typography>
+                <Tooltip
+                  title={email}
+                  placement="top-start"
+                  arrow
+                  slotProps={{
+                    popper: {
+                      modifiers: [
+                        { name: "offset", options: { offset: [0, -14] } },
+                      ],
+                    },
+                  }}
+                >
+                  <Typography variant="h6" noWrap>
+                    {" "}
+                    {email}{" "}
+                  </Typography>
                 </Tooltip>
               </Stack>
-
-              <Stack direction="row" spacing={1} alignItems="center" width="45%">
+              <Stack
+                direction="row"
+                spacing={1}
+                alignItems="center"
+                width="45%"
+              >
                 <PhoneIphoneIcon fontSize="large" />
                 <Typography variant="h6"> {phone} </Typography>
               </Stack>
             </Stack>
-
             <Stack direction="row" spacing={1} alignItems="center">
               <FormatAlignLeftIcon fontSize="large" />
-
-              { appointment?.tuteeRequestComment ?
-              <Typography variant="h6"> {appointment?.tuteeRequestComment} </Typography>
-              :
-              <Typography variant="body1" color="text.secondary"> Tutee left no additional request details . . . </Typography>
-              }
+              {appointment?.tuteeRequestComment ? (
+                <Typography variant="h6">
+                  {" "}
+                  {appointment?.tuteeRequestComment}{" "}
+                </Typography>
+              ) : (
+                <Typography variant="body1" color="text.secondary">
+                  {" "}
+                  No details{" "}
+                </Typography>
+              )}
             </Stack>
           </Stack>
-          
-          
+
           {/* Button Row */}
-          <Stack direction="row" justifyContent="space-between" pt={1} borderTop={1} borderColor="divider">
-            { !isConfirmed && (sessionEmail === appointment?.tutorEmail) && 
-            <Button variant="contained" color="success" startIcon={ <DoneIcon /> } onClick={handleConfirm}> Accept Request </Button> 
-            }
-
-            { !isCancelled && 
-            <Button variant="contained" color="error" startIcon={ <DoNotDisturbIcon /> } onClick={handleCancel}> 
-              { (sessionEmail === appointment?.tutorEmail) ? 
-                (isConfirmed ? "Cancel Appointment" : "Deny Request") : 
-                (isConfirmed ? "Cancel Appointment" : "Delete Request") 
-              } 
-            </Button> 
-            }
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            pt={1}
+            borderTop={1}
+            borderColor="divider"
+          >
+            {!isConfirmed && sessionEmail === appointment?.tutorEmail && (
+              <Button
+                variant="contained"
+                color="success"
+                startIcon={<DoneIcon />}
+                onClick={handleConfirm}
+              >
+                {" "}
+                Accept Request{" "}
+              </Button>
+            )}
+            {!isCancelled && (
+              <Button
+                variant="contained"
+                color="error"
+                startIcon={<DoNotDisturbIcon />}
+                onClick={handleCancel}
+              >
+                {sessionEmail === appointment?.tutorEmail
+                  ? isConfirmed
+                    ? "Cancel Appointment"
+                    : "Deny Request"
+                  : isConfirmed
+                  ? "Cancel Appointment"
+                  : "Delete Request"}
+              </Button>
+            )}
           </Stack>
-
         </Stack>
-
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/app/(ui)/dashboard/schedule/schedule.tsx
+++ b/frontend/src/app/(ui)/dashboard/schedule/schedule.tsx
@@ -1,24 +1,13 @@
+import * as React from "react";
+import { Stack } from "@mui/material";
+import FullCalendar from "@fullcalendar/react";
+import timeGridPlugin from "@fullcalendar/timegrid";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import interactionPlugin from "@fullcalendar/interaction";
+import type { EventClickArg, EventInput } from "@fullcalendar/core/index.js";
+import { toTitleCase } from "@/app/_lib/utils";
+import EventItem from "./event-item";
 
-
-import * as React from 'react';
-
-import { Stack }
-  from '@mui/material';
-
-import FullCalendar from '@fullcalendar/react';
-import timeGridPlugin from '@fullcalendar/timegrid';
-import dayGridPlugin from '@fullcalendar/daygrid';
-
-import interactionPlugin from '@fullcalendar/interaction';
-import type { EventClickArg, EventInput } 
-  from '@fullcalendar/core/index.js';
-
-import { toTitleCase }
-  from '@/app/_lib/utils';
-import EventItem from './event-item';
-
-
-// 
 function mapEventColor(isConfirmed: boolean, isCancelled: boolean) {
   if (!isConfirmed && !isCancelled) {
     return "#b4b4b8";
@@ -27,97 +16,173 @@ function mapEventColor(isConfirmed: boolean, isCancelled: boolean) {
   } else if (isConfirmed && isCancelled) {
     return "#ffb3ba";
   }
-  
+
   return "black";
 }
 
-
-/**
- * Component for displaying the FullCalendar Schedule containing tutor and tutee appointments and requests.
- * @param tutorEventData - Appointment list containing the signed-in user's queried tutor appointments
- * @param tuteeEventData - Appointment list containing the signed-in users's queried tutee appointments
- * @param refetch - Refetch functions for refreshing the tutor and tutee queries in the schedule page
- * @returns 
- */  
-export default function Schedule(
-  { tutorEventData, tuteeEventData, refetch: [tutorRefetch, tuteeRefetch] } : 
-  { tutorEventData: Appointment[], tuteeEventData: Appointment[], refetch: [Function, Function] }
-){
+export default function Schedule({
+  tutorEventData,
+  tuteeEventData,
+  refetch: [tutorRefetch, tuteeRefetch],
+}: {
+  tutorEventData: Appointment[];
+  tuteeEventData: Appointment[];
+  refetch: [Function, Function];
+}) {
   const currentTime = new Date();
-  
-  // State variables controlling the selected event and boolean status of the EventItem popup
   const [event, setEvent] = React.useState<Appointment>();
   const [eventOpen, setEventOpen] = React.useState(false);
+  const [view, setView] = React.useState("timeGridWeek"); // Track the current view
+  const [events, setEvents] = React.useState<EventInput[]>([]); // State to hold events
 
-  // Handler function for opening the custom EventItem component popup
+  // Effect to update events when view changes
+  React.useEffect(() => {
+    // Function to fetch events based on current view
+    const fetchEvents = () => {
+      if (view === "dayGridMonth") {
+        setEvents(formatMonth()); // This is used to ensure that Months doesnt display the topic.
+      } else {
+        setEvents(formatEvents());
+      }
+    };
+
+    fetchEvents(); // Fetch events initially
+  }, [view, tutorEventData, tuteeEventData]); // Update when view or event data changes
+
+  const formatEvents = () => {
+    return tutorEventData
+      ?.map<EventInput>((appointment: Appointment) => ({
+        title: toTitleCase(
+          `Tutee: ${appointment.tuteeFirstName} ${appointment.tuteeLastName}`
+        ),
+        description: `Topic: ${
+          appointment.tuteeRequestComment
+            ? appointment.tuteeRequestComment
+            : "No details"
+        }`,
+        start: appointment.startDateTimeString,
+        end: appointment.endDateTimeString,
+        data: appointment,
+        textColor: "black",
+        color: mapEventColor(appointment.isConfirmed, appointment.isCancelled),
+        url: "click",
+      }))
+      .concat(
+        tuteeEventData?.map<EventInput>((appointment: Appointment) => ({
+          title: toTitleCase(
+            `Tutor: ${appointment.tutorFirstName} ${appointment.tutorLastName}`
+          ),
+          description: toTitleCase(
+            `Topic: ${
+              appointment.tuteeRequestComment
+                ? appointment.tuteeRequestComment
+                : "No details"
+            }`
+          ),
+          start: appointment.startDateTimeString,
+          end: appointment.endDateTimeString,
+          data: appointment,
+          color: mapEventColor(
+            appointment.isConfirmed,
+            appointment.isCancelled
+          ),
+          textColor: "black",
+          url: "click",
+          isConfirmed: appointment.isConfirmed,
+          isCancelled: appointment.isCancelled,
+        })) as ConcatArray<EventInput>
+      );
+  };
+
+  const formatMonth = () => {
+    return tutorEventData
+      ?.map<EventInput>((appointment: Appointment) => ({
+        title: toTitleCase(
+          `Tutee: ${appointment.tuteeFirstName} ${appointment.tuteeLastName}`
+        ),
+
+        start: appointment.startDateTimeString,
+        end: appointment.endDateTimeString,
+        data: appointment,
+        textColor: "black",
+        color: mapEventColor(appointment.isConfirmed, appointment.isCancelled),
+        url: "click",
+      }))
+      .concat(
+        tuteeEventData?.map<EventInput>((appointment: Appointment) => ({
+          title: toTitleCase(
+            `Tutor: ${appointment.tutorFirstName} ${appointment.tutorLastName}`
+          ),
+
+          start: appointment.startDateTimeString,
+          end: appointment.endDateTimeString,
+          data: appointment,
+          color: mapEventColor(
+            appointment.isConfirmed,
+            appointment.isCancelled
+          ),
+          textColor: "black",
+          url: "click",
+          isConfirmed: appointment.isConfirmed,
+          isCancelled: appointment.isCancelled,
+        })) as ConcatArray<EventInput>
+      );
+  };
+
   const handleEventClick = (currentEvent: EventClickArg) => {
     currentEvent.jsEvent.preventDefault();
     setEventOpen(true);
     setEvent(currentEvent.event.extendedProps.data as Appointment);
   };
 
-  // Helper function for formatting events into schedule as FullCalendar Events
-  const formatEvents = () => {
-    return tutorEventData?.map<EventInput>((appointment: Appointment) => (
-      { 
-        title: toTitleCase(`Tutee: ${appointment.tuteeFirstName} ${appointment.tuteeLastName}`),
-        start: appointment.startDateTimeString,
-        end: appointment.endDateTimeString,
-
-        data: appointment,
-        textColor: 'black',
-        color: mapEventColor(appointment.isConfirmed, appointment.isCancelled),
-        url: "click",
-        // backgroundColor: mapEventColor(appointment.isConfirmed, appointment.isCancelled),
-        // borderColor: 'black'
-      }
-    )).concat( tuteeEventData?.map<EventInput>((appointment: Appointment) => (
-      {
-        title: toTitleCase(`Tutor: ${appointment.tutorFirstName} ${appointment.tutorLastName}`),
-        start: appointment.startDateTimeString,
-        end: appointment.endDateTimeString,
-
-        data: appointment,
-        color: mapEventColor(appointment.isConfirmed, appointment.isCancelled),
-        textColor: 'black',
-        url: "click",
-        isConfirmed: appointment.isConfirmed,
-        isCancelle: appointment.isCancelled
-      }
-      )) as ConcatArray<EventInput>
-    );
-  };
-
-
   return (
     <Stack direction="column" spacing={2} width="100%">
-      <FullCalendar 
-        plugins={[ interactionPlugin, dayGridPlugin, timeGridPlugin ]}
-        
+      <FullCalendar
+        plugins={[interactionPlugin, dayGridPlugin, timeGridPlugin]}
         initialView="timeGridWeek"
-
         height="70vh"
         headerToolbar={{
-          left: 'prev,next today',
-          center: 'title',
-          right: 'dayGridMonth,timeGridWeek,timeGridDay',
+          left: "prev,next today",
+          center: "title",
+          right: "dayGridMonth,timeGridWeek,timeGridDay",
         }}
         buttonText={{
-          today: 'Today',
-          month: 'Month',
-          week: 'Week',
-          day: 'Day',
+          today: "Today",
+          month: "Month",
+          week: "Week",
+          day: "Day",
         }}
-
-        allDaySlot={false} slotDuration="00:15:00" slotLabelInterval="01:00"
-        events={formatEvents()} 
-        eventClick={handleEventClick} 
+        allDaySlot={false}
+        slotDuration="00:15:00"
+        slotLabelInterval="01:00"
+        events={events}
+        eventClick={handleEventClick}
         eventOverlap={false}
+        nowIndicator
+        scrollTime={currentTime.toLocaleTimeString("it-IT")}
+        scrollTimeReset={false}
+        eventContent={function (arg) {
+          return (
+            <>
+              <b>{arg.event.title}</b>
+              <br />
+              {arg.event.extendedProps.description}
+            </>
+          );
+        }}
+        viewDidMount={(info) => {
+          setView(info.view.type);
 
-        nowIndicator scrollTime={currentTime.toLocaleTimeString('it-IT')} scrollTimeReset={false}
+          info.view.type === "dayGridMonth"
+            ? setEvents(formatMonth())
+            : setEvents(formatEvents());
+        }}
       />
-
-      <EventItem appointment={event} event={[eventOpen, setEventOpen]} refetch={[tutorRefetch, tuteeRefetch]} />
+      <EventItem
+        appointment={event}
+        event={[eventOpen, setEventOpen]}
+        refetch={[tutorRefetch, tuteeRefetch]}
+      />
     </Stack>
   );
 }

--- a/frontend/src/app/(ui)/dashboard/tutors/tutor-profile-schedule.tsx
+++ b/frontend/src/app/(ui)/dashboard/tutors/tutor-profile-schedule.tsx
@@ -199,7 +199,7 @@ export default function TutorProfileSchedule({
   };
 
   const handleCommentChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (event.target.value.split(/\s+/).length <= 200) {
+    if (event.target.value.split(/\s+/).length <= 50) {
       setTuteeRequestComment(event.target.value);
     }
   };
@@ -213,7 +213,7 @@ export default function TutorProfileSchedule({
         variant="outlined"
         value={tuteeRequestComment}
         onChange={handleCommentChange}
-        helperText={`${tuteeRequestComment.split(/\s+/).length}/200 words`}
+        helperText={`${tuteeRequestComment.split(/\s+/).length}/50 words`}
       />
 
       <Stack direction="column" spacing={2} width="100%">
@@ -269,7 +269,7 @@ export default function TutorProfileSchedule({
           >
             {tutorTimeRequest.isSuccess
               ? "Request Successfully Sent!"
-              : "Request Failed"}
+              : "Request Failed, Reason: You arent a registered tutee yet!"}
           </Alert>
         </Snackbar>
       </Stack>

--- a/frontend/src/app/(ui)/dashboard/tutors/tutor-profile-schedule.tsx
+++ b/frontend/src/app/(ui)/dashboard/tutors/tutor-profile-schedule.tsx
@@ -1,36 +1,33 @@
-
-
-import * as React from 'react';
-
+import * as React from "react";
 import { useUser } from "@auth0/nextjs-auth0/client";
 
-import { TransitionProps }
-  from '@mui/material/transitions';
-import { Stack, Snackbar, Alert, Slide }
-  from '@mui/material';
-
-import FullCalendar from '@fullcalendar/react';
-import timeGridPlugin from '@fullcalendar/timegrid';
-import dayGridPlugin from '@fullcalendar/daygrid';
-import interactionPlugin from '@fullcalendar/interaction';
-import type { DateSelectArg, EventInput } 
-  from '@fullcalendar/core/index.js';
-
-import { TableFetch, TablePush }
-  from '@/app/_lib/data';
-import { toTitleCase } 
-  from '@/app/_lib/utils';
-
+import { useSession } from "next-auth/react";
+import { TransitionProps } from "@mui/material/transitions";
+import {
+  Stack,
+  Snackbar,
+  Alert,
+  Slide,
+  TextField,
+  Button,
+} from "@mui/material";
+import FullCalendar from "@fullcalendar/react";
+import timeGridPlugin from "@fullcalendar/timegrid";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import interactionPlugin from "@fullcalendar/interaction";
+import type { DateSelectArg, EventInput } from "@fullcalendar/core/index.js";
+import { TableFetch, TablePush } from "@/app/_lib/data";
+import { toTitleCase } from "@/app/_lib/utils";
 
 // Mapping of week days to its corresponding numerical value
-const Day: { [key: string]: number } = { 
-  "sunday": 0, 
-  "monday": 1, 
-  "tuesday": 2, 
-  "wednesday": 3, 
-  "thursday": 4, 
-  "friday": 5, 
-  "saturday": 6 
+const Day: { [key: string]: number } = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
 };
 
 // Transition element for popup components
@@ -38,22 +35,24 @@ const AlertTransition = React.forwardRef(function Transition(
   props: TransitionProps & {
     children: React.ReactElement<any, any>;
   },
-  ref: React.Ref<unknown>,
+  ref: React.Ref<unknown>
 ) {
   return <Slide direction="right" ref={ref} {...props} />;
 });
 
-
 /**
  * Component for displaying a tutor's FullCalendar schedule on their profile
  * @param tutor - A 'Tutor' value to query for appointments. Can be 'null' value as well when values are not initially populated
- * @returns 
- */  
-export default function TutorProfileSchedule({ tutor } : { tutor: Tutor | null }) {
+ * @returns
+ */
+export default function TutorProfileSchedule({
+  tutor,
+}: {
+  tutor: Tutor | null;
+}) {
   const calendar = React.createRef<FullCalendar>();
   const currentTime = new Date();
   const tutorName = toTitleCase(`${tutor?.firstName} ${tutor?.lastName}`);
-
   const { user } = useUser();
   const tuteeEmail = user?.email;
 
@@ -61,33 +60,40 @@ export default function TutorProfileSchedule({ tutor } : { tutor: Tutor | null }
   const [selectedTime, setSelectedTime] = React.useState<String[]>();
   const [alertOpen, setAlertOpen] = React.useState(false);
 
+  //This array allows us to save the comment the tutee makes for the allocated time slot.
+  const [tuteeRequestComment, setTuteeRequestComment] = React.useState("");
 
   // Appointment Queries for selected tutor and user's tutee profile
-  const { data: tutorEvents } = TableFetch<AppointmentQuery>("appointment", [tutor, "tutor"], 
-    `tutor_email_contains=${tutor?.email}`, 
+  const { data: tutorEvents } = TableFetch<AppointmentQuery>(
+    "appointment",
+    [tutor, "tutor"],
+    `tutor_email_contains=${tutor?.email}`,
     `is_cancelled_equals=${false}`,
     `is_confirmed_equals=${true}`
-    // `start_date_time_greater_than_or_equals=${new Date()}`
-  );
-  const { data: tuteeEvents } = TableFetch<AppointmentQuery>("appointment", [tutor, "tutee"], 
-    `tutee_email_contains=${tutor?.email}`, 
-    `is_cancelled_equals=${false}`,
-    `is_confirmed_equals=${true}`
-    // `start_date_time_greater_than_or_equals=${new Date()}`
   );
 
-  const { data: userTutorEvents } = TableFetch<AppointmentQuery>("appointment", [tuteeEmail, "tutor"], 
-    `tutor_email_contains=${tuteeEmail}`, 
+  const { data: tuteeEvents } = TableFetch<AppointmentQuery>(
+    "appointment",
+    [tutor, "tutee"],
+    `tutee_email_contains=${tutor?.email}`,
     `is_cancelled_equals=${false}`,
     `is_confirmed_equals=${true}`
-    // `start_date_time_greater_than_or_equals=${new Date()}`
   );
 
-  const { data: userTuteeEvents } = TableFetch<AppointmentQuery>("appointment", [tuteeEmail, "tutee"], 
-    `tutee_email_contains=${tuteeEmail}`, 
+  const { data: userTutorEvents } = TableFetch<AppointmentQuery>(
+    "appointment",
+    [tuteeEmail, "tutor"],
+    `tutor_email_contains=${tuteeEmail}`,
     `is_cancelled_equals=${false}`,
     `is_confirmed_equals=${true}`
-    // `start_date_time_greater_than_or_equals=${new Date()}`
+  );
+
+  const { data: userTuteeEvents } = TableFetch<AppointmentQuery>(
+    "appointment",
+    [tuteeEmail, "tutee"],
+    `tutee_email_contains=${tuteeEmail}`,
+    `is_cancelled_equals=${false}`,
+    `is_confirmed_equals=${true}`
   );
 
   // Mutation handler for creating appointment requests
@@ -95,55 +101,57 @@ export default function TutorProfileSchedule({ tutor } : { tutor: Tutor | null }
 
   // Getter function for mapping tutor and tutee's appointment information to FullCalendar Event format as one large array
   const getEvents = () => {
-    if (tutor && tutorEvents && tuteeEvents && userTutorEvents && userTuteeEvents)
-    return tutor.timePreferences.map<EventInput>((timePreference: TutorTimePreference) => (
-      { 
-        groupId: "timePreference",
-
-        startTime: timePreference.startTimeString,
-        endTime: timePreference.endTimeString,
-        daysOfWeek: [ Day[timePreference.weekdayName] ],
-
-        display: 'background',
-        //color: '#ccc'
-      }
-    )).concat( tutorEvents.data.map<EventInput>((event: Appointment) => (
-      {
-        title: "Unavailable",
-        start: event.startDateTimeString,
-        end: event.endDateTimeString,
-        textColor: "black",
-        color: "lightgrey"
-      }
-    )) as ConcatArray<EventInput>
-    ).concat( tuteeEvents.data.map<EventInput>((event: Appointment) => (
-      {
-        title: "Unavailable",
-        start: event.startDateTimeString,
-        end: event.endDateTimeString,
-        textColor: "black",
-        color: "lightgrey"
-      }
-    )) as ConcatArray<EventInput>
-    ).concat( userTutorEvents.data.map<EventInput>((event: Appointment) => (
-      {
-        title: `Tutor: ${event.tuteeEmail}`,
-        start: event.startDateTimeString,
-        end: event.endDateTimeString,
-        textColor: 'black',
-        color: "#ffb3ba"
-      }
-    )) as ConcatArray<EventInput>
-    ).concat( userTuteeEvents.data.map<EventInput>((event: Appointment) => (
-      {
-        title: `Tutee: ${event.tutorEmail}`,
-        start: event.startDateTimeString,
-        end: event.endDateTimeString,
-        textColor: 'black',
-        color: "#ffb3ba"
-      }
-    )) as ConcatArray<EventInput>
-    );
+    if (
+      tutor &&
+      tutorEvents &&
+      tuteeEvents &&
+      userTutorEvents &&
+      userTuteeEvents
+    )
+      return tutor.timePreferences
+        .map<EventInput>((timePreference: TutorTimePreference) => ({
+          groupId: "timePreference",
+          startTime: timePreference.startTimeString,
+          endTime: timePreference.endTimeString,
+          daysOfWeek: [Day[timePreference.weekdayName]],
+          display: "background",
+        }))
+        .concat(
+          tutorEvents.data.map<EventInput>((event: Appointment) => ({
+            title: "Unavailable",
+            start: event.startDateTimeString,
+            end: event.endDateTimeString,
+            textColor: "black",
+            color: "lightgrey",
+          }))
+        )
+        .concat(
+          tuteeEvents.data.map<EventInput>((event: Appointment) => ({
+            title: "Unavailable",
+            start: event.startDateTimeString,
+            end: event.endDateTimeString,
+            textColor: "black",
+            color: "lightgrey",
+          }))
+        )
+        .concat(
+          userTutorEvents.data.map<EventInput>((event: Appointment) => ({
+            title: `Tutor: ${event.tuteeEmail}`,
+            start: event.startDateTimeString,
+            end: event.endDateTimeString,
+            textColor: "black",
+            color: "#ffb3ba",
+          }))
+        )
+        .concat(
+          userTuteeEvents.data.map<EventInput>((event: Appointment) => ({
+            title: `Tutee: ${event.tutorEmail}`,
+            start: event.startDateTimeString,
+            end: event.endDateTimeString,
+            textColor: "black",
+            color: "#ffb3ba",
+          }))
+        );
   };
 
   // Handler functions
@@ -157,89 +165,114 @@ export default function TutorProfileSchedule({ tutor } : { tutor: Tutor | null }
         {
           tutor_email: tutor?.email,
           tutee_email: tuteeEmail,
-          
+
           appointment_size_name: "single",
-          location_name: 'online',
+          location_name: "online",
 
-          start_date_time: selectedTime[0].slice(0, selectedTime[0].lastIndexOf('-')),
-          end_date_time: selectedTime[1].slice(0, selectedTime[1].lastIndexOf('-')),
+          start_date_time: selectedTime[0].slice(
+            0,
+            selectedTime[0].lastIndexOf("-")
+          ),
+          end_date_time: selectedTime[1].slice(
+            0,
+            selectedTime[1].lastIndexOf("-")
+          ),
 
-          tutee_request_comment: "",
-        }, 
-        { 
+          tutee_request_comment: tuteeRequestComment,
+        },
+        {
           onSettled: (data, error, variables, context) => {
             setAlertOpen(true);
-          }, 
+          },
         }
       );
     }
   };
 
-  const handleAlertClose = (event?: React.SyntheticEvent | Event, reason?: string) => {
+  const handleAlertClose = (
+    event?: React.SyntheticEvent | Event,
+    reason?: string
+  ) => {
     if (reason === "clickaway") return;
 
     setAlertOpen(false);
   };
 
+  const handleCommentChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.value.split(/\s+/).length <= 200) {
+      setTuteeRequestComment(event.target.value);
+    }
+  };
 
   return (
-    <Stack direction="row" width="100%" spacing={4} justifyContent="center">
-      
+    <Stack direction="column" width="100%" spacing={4} justifyContent="center">
+      <TextField
+        label="Discussion/Clarification"
+        multiline
+        fullWidth
+        variant="outlined"
+        value={tuteeRequestComment}
+        onChange={handleCommentChange}
+        helperText={`${tuteeRequestComment.split(/\s+/).length}/200 words`}
+      />
+
       <Stack direction="column" spacing={2} width="100%">
-        <FullCalendar 
+        <FullCalendar
           ref={calendar}
-          plugins={[ interactionPlugin, dayGridPlugin, timeGridPlugin ]}
-          
+          plugins={[interactionPlugin, dayGridPlugin, timeGridPlugin]}
           initialView="timeGridWeek"
-          validRange={ function(currentDate){
+          validRange={function (currentDate) {
             return {
               start: currentDate,
               end: new Date(currentDate).setMonth(currentDate.getMonth() + 1),
             };
           }}
-
           height="80vh"
           headerToolbar={{
-            left: 'prev,next today',
-            center: 'title',
-            right: 'tutorRequest timeGridWeek,timeGridDay',
+            left: "prev,next today",
+            center: "title",
+            right: "tutorRequest timeGridWeek,timeGridDay",
           }}
           buttonText={{
-            today: 'Today',
-            week: 'Week',
-            day: 'Day',
+            today: "Today",
+            week: "Week",
+            day: "Day",
           }}
           customButtons={{
             tutorRequest: {
-              text: 'Request Selected Time',
+              text: "Request Selected Time",
               click: handleTutorTimeRequestQuery,
-            }
+            },
           }}
-          allDaySlot={false} slotDuration="00:15:00" slotLabelInterval="01:00"
-          unselectAuto={false}
-          selectable selectMirror selectOverlap={(event) => (event.display === 'background')}
-          eventOverlap={false}
-          events={getEvents()} // eventColor={theme.palette.primary.main}
-
+          allDaySlot={false}
+          slotDuration="00:15:00"
+          slotLabelInterval="00:30:00"
+          editable={false}
+          selectMirror={true}
+          dayMaxEvents={true}
+          selectable={true}
           select={handleDateSelect}
-        
-          nowIndicator scrollTime={currentTime.toLocaleTimeString('it-IT')} scrollTimeReset={false}
+          events={getEvents}
         />
-      </Stack>
 
-      <Snackbar anchorOrigin={{ vertical: "bottom", horizontal: "right" }} open={alertOpen} TransitionComponent={AlertTransition} autoHideDuration={5000} onClose={handleAlertClose}>
-        <Alert
+        <Snackbar
+          open={alertOpen}
+          autoHideDuration={10000}
           onClose={handleAlertClose}
-          severity={tutorTimeRequest.isSuccess ? "success" : "error"}
-          sx={{ width: '100%' }}
+          TransitionComponent={AlertTransition}
         >
-          { tutorTimeRequest.isSuccess ?
-          "Request Successfully Sent!"
-          :
-          "Request Failed"
-          }
-        </Alert>
-      </Snackbar>
+          <Alert
+            onClose={handleAlertClose}
+            severity={tutorTimeRequest.isSuccess ? "success" : "error"}
+            variant="filled"
+            sx={{ width: "100%" }}
+          >
+            {tutorTimeRequest.isSuccess
+              ? "Request Successfully Sent!"
+              : "Request Failed"}
+          </Alert>
+        </Snackbar>
+      </Stack>
     </Stack>
   );
 }


### PR DESCRIPTION
Summary:

Added the option to add " discussion/clarification" to the request scheduled time in the "tutors" tab.
Went over to the schedule component and had it display the comment as a description.
Added 50 word limit to the discussion
Added logic to the "month" tab so it does not display the topic cause there is simply too little space.
Note: Schedule modifications work on both the Tutee AND Tutor ends.
There is 1 bug in it, nothing huge, but if a user have a massive description, or a really small window of allocated time, the text can overlap in the schedule view. Making it bleed over the box. Again not massive but I have no idea how to work on that part.